### PR TITLE
make pictures unstretch, factor out .inputBox from #textBox and #imgBox

### DIFF
--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -33,32 +33,25 @@ h1 {
 }
 
 .inputBox {
-  margin-left: 25%;
+  height: 10em;
   margin-right: auto;
-  width: 50%;
-  height: 125px;
-  background-color: white;
+  margin-left: auto;
 }
 
 #textBox {
-  /*
   margin-left: 25%;
-  margin-right: auto;
   width: 50%;
-  height: 125px;
   background-color: white;
-  */
 }
 
 #imgBox {
-  max-height: 125px;
-  height: auto;
+
   visibility: hidden;
 }
 
 #analyze {
   max-width: 12%;
-  height: 100px;
+  height: 4em;
   margin: 0 auto;
   background-image: url(../images/preclickButton.png);
   background-size: contain;


### PR DESCRIPTION
The pictures are unstreched, but do either of you remember why 10ems is different for an image and a textbox height? I thought the picture would just show up in the same place, but it is moving the '???' button down a little bit.
