### PR TITLE
consider inputBox not empty on copy/paste

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -201,7 +201,8 @@ addDragListenersToId("textBox");
 addDragListenersToId("imgBox");
 
 //Set up individiual Event Listeners
-eltextbox.addEventListener("keypress", input.userType, false);
+eltextbox.addEventListener("input", input.userType, false);
+eltextbox.addEventListener("paste", input.userType, false);
 elanalyze.addEventListener("click", input.runSubmit, false);
 elanalyze.addEventListener("click", button.hide, false);
 


### PR DESCRIPTION
well, it's still possible that someone could select all the text that _IS_ in the box, and delete it, and we will not consider _THAT_ empty, but this is a big improvement
